### PR TITLE
Fix: Add environment configuration to GitHub Pages deployment job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
- Updated `.github/workflows/deploy.yml` to include the `environment` setting (name: github-pages, url: ${{ steps.deployment.outputs.page_url }}) in the `build-and-deploy` job.

This is required by `actions/deploy-pages@v4` and resolves the "Missing environment" error during deployment.